### PR TITLE
Fix systemd startup service issue

### DIFF
--- a/systemd/tinyticker-qrcode.service
+++ b/systemd/tinyticker-qrcode.service
@@ -4,6 +4,7 @@ After=networking.service
 
 [Service]
 Type=oneshot
+User=tinyticker
 ExecStartPre=/usr/bin/mkdir -p /home/tinyticker/.local/share/tinyticker
 ExecStart=/home/tinyticker/.local/bin/tinyticker-web --port 80 --show-qrcode --config /home/tinyticker/.config/tinyticker/config.json
 Restart=on-failure

--- a/systemd/tinyticker-web.service
+++ b/systemd/tinyticker-web.service
@@ -4,6 +4,7 @@ After=networking.service
 
 [Service]
 Type=simple
+User=tinyticker
 ExecStartPre=/usr/bin/mkdir -p /home/tinyticker/.local/share/tinyticker
 ExecStart=sh -c '! type comitup-cli || comitup-cli i | grep -q "CONNECTED" && /home/tinyticker/.local/bin/tinyticker-web --port 80 --config /home/tinyticker/.config/tinyticker/config.json --log-dir /home/tinyticker/ -vv'
 Restart=on-failure

--- a/systemd/tinyticker.service
+++ b/systemd/tinyticker.service
@@ -5,6 +5,7 @@ After=tinyticker-qrcode.service
 
 [Service]
 Type=simple
+User=tinyticker
 ExecStartPre=/usr/bin/mkdir -p /home/tinyticker/.local/share/tinyticker
 ExecStart=/home/tinyticker/.local/bin/tinyticker --config /home/tinyticker/.config/tinyticker/config.json -vv
 Restart=on-failure


### PR DESCRIPTION
When starting tinyticker as a systemd service without specifying the user the service fails to start as the tinyticker pip module is not installed for the root user. ie.

ModuleNotFoundError: No module named 'tinyticker'