### PR TITLE
feat: add `skip_outdated` toggle

### DIFF
--- a/tests/data/config.json
+++ b/tests/data/config.json
@@ -41,6 +41,10 @@
       "volume": false
     }
   ],
+  "sequence": {
+    "skip_outdated": true,
+    "skip_empty": true
+  },
   "epd_model": "EPDbc",
   "api_key": "SUPERSECRETKEY",
   "flip": true

--- a/tests/unit/test_ticker.py
+++ b/tests/unit/test_ticker.py
@@ -148,12 +148,10 @@ class TestSequence(TestCase):
 
     def test_sequence_from_tt_config(self):
         tt_config = config.TinytickerConfig.from_file(self.config_path)
-        sequence = ticker.Sequence.from_tinyticker_config(
-            tt_config, skip_empty=False, skip_outdated=False
-        )
+        sequence = ticker.Sequence.from_tinyticker_config(tt_config)
         assert len(sequence.tickers) == len(tt_config.tickers)
-        assert sequence.skip_empty is False
-        assert sequence.skip_outdated is False
+        assert sequence.skip_empty is True
+        assert sequence.skip_outdated is True
 
     def test_sequence_order(self):
         sequence = self.sequence

--- a/tinyticker/config.py
+++ b/tinyticker/config.py
@@ -23,8 +23,15 @@ class TickerConfig:
 
 
 @dc.dataclass
+class SequenceConfig:
+    skip_outdated: bool = True
+    skip_empty: bool = True
+
+
+@dc.dataclass
 class TinytickerConfig:
     tickers: List[TickerConfig] = dc.field(default_factory=lambda: [TickerConfig()])
+    sequence: SequenceConfig = dc.field(default_factory=lambda: SequenceConfig())
     epd_model: str = "EPD_v3"
     api_key: Optional[str] = None
     flip: bool = False
@@ -44,6 +51,9 @@ class TinytickerConfig:
         data["tickers"] = [
             TickerConfig(**ticker_data) for ticker_data in data["tickers"]
         ]
+        data["sequence"] = SequenceConfig(
+            **data.get("sequence", dc.asdict(SequenceConfig()))
+        )
         return cls(**data)
 
     def to_json(self) -> str:

--- a/tinyticker/ticker.py
+++ b/tinyticker/ticker.py
@@ -340,14 +340,11 @@ class Ticker:
 
 class Sequence:
     @classmethod
-    def from_tinyticker_config(
-        cls, tt_config: TinytickerConfig, **kwargs
-    ) -> "Sequence":
+    def from_tinyticker_config(cls, tt_config: TinytickerConfig) -> "Sequence":
         """Create a `Sequence` from a `TinytickerConfig`.
 
         Args:
             tt_config: `TinytickerConfig` from which to create the `Sequence`.
-            **kwargs: Paseed to the `Sequence.__init__` method.
 
         Returns:
             The `Sequence` instance.
@@ -367,7 +364,8 @@ class Sequence:
                 )
                 for ticker in tt_config.tickers
             ],
-            **kwargs,
+            skip_empty=tt_config.sequence.skip_empty,
+            skip_outdated=tt_config.sequence.skip_outdated,
         )
 
     def __init__(
@@ -380,10 +378,9 @@ class Sequence:
 
         Args:
             tickers: list of `Ticker` instances.
-            skip_empty: if the response doesn't contain any data, move on to the
-                next ticker.
-            skip_outdated: if the last candle of the response is too old, move on to the
-                next ticker. This typically happens when the stock market closes.
+            skip_empty: if the response doesn't contain any data, move on to the next ticker.
+            skip_outdated: if the last candle of the response is too old, move on to the next
+                ticker. This typically happens when the stock market closes.
         """
         if len(tickers) == 0:
             raise ValueError("No tickers provided.")
@@ -436,4 +433,7 @@ class Sequence:
                 time.sleep(ticker.wait_time)
 
     def __str__(self):
-        return "Sequence: \n" + "\n".join([ticker.__str__() for ticker in self.tickers])
+        return (
+            f"Sequence(skip_outdated={self.skip_outdated}, skip_empty={self.skip_empty}): \n"
+            + "\n".join([ticker.__str__() for ticker in self.tickers])
+        )

--- a/tinyticker/web/templates/index.html
+++ b/tinyticker/web/templates/index.html
@@ -135,6 +135,7 @@
                 </div>
               </div>
               <div class="uk-width-1-1 uk-margin">
+                <label class="uk-form-label" for="skip_outdated" uk-tooltip="Typically happens when the market is closed."><input class="uk-checkbox uk-margin-small-right" type="checkbox" id="skip_outdated" name="skip_outdated" {% if sequence.skip_outdated | default(True) %}checked{% endif %}>Skip tickers with oudated data</label>
                 <button type="submit" value="submit" class="uk-button uk-button-primary uk-width-expand">Apply</button>
               </div>
             </div>


### PR DESCRIPTION
Adds an option to toggle the skipping of tickers when its data is not recent (this typically happens when the market closed).

closes #37 #41 