### PR TITLE
feat: pre/post market option for stock tickers

### DIFF
--- a/tests/unit/web/test_app.py
+++ b/tests/unit/web/test_app.py
@@ -65,6 +65,7 @@ def test_config(client: FlaskClient):
         "mav": [3, ""],
         "volume": [1, ""],
         "avg_buy_price": ["", 100],
+        "prepost": [1, ""],
         "flip": True,
         "epd_model": "EPD_V3",
         "api_key": "SOMEKEY",

--- a/tinyticker/config.py
+++ b/tinyticker/config.py
@@ -21,6 +21,7 @@ class TickerConfig:
     mav: Optional[int] = None
     volume: bool = False
     avg_buy_price: Optional[float] = None
+    prepost: bool = False
 
 
 @dc.dataclass

--- a/tinyticker/ticker.py
+++ b/tinyticker/ticker.py
@@ -173,6 +173,7 @@ class Ticker:
         lookback: How many intervals to look back.
         wait_time: Time to wait in between API calls.
         avg_buy_price: Average buy price of the asset.
+        prepost: Include pre/post market data, only relevant for "stock" tickers.
         **kwargs: Extra args are provided to the `Display.plot` method.
     """
 
@@ -185,6 +186,7 @@ class Ticker:
         lookback: Optional[int] = None,
         wait_time: Optional[int] = None,
         avg_buy_price: Optional[float] = None,
+        prepost: bool = False,
         **kwargs,
     ) -> None:
         self._log = logging.getLogger(__name__)
@@ -209,7 +211,7 @@ class Ticker:
             self.lookback = INTERVAL_LOOKBACKS[self.interval]
         else:
             self._log.debug("lookback not None")
-            self.lookback = lookback  # type: int
+            self.lookback = lookback
         self._log.debug("lookback: %s", self.lookback)
         if wait_time is None:
             self.wait_time = int(self._interval_dt.value * 1e-9)
@@ -221,6 +223,7 @@ class Ticker:
             "stock": self._tick_stock,
         }
         self.avg_buy_price = avg_buy_price
+        self.prepost = prepost
         self._display_kwargs = kwargs
 
     @property
@@ -296,6 +299,7 @@ class Ticker:
             start=end - pd.to_timedelta("2m"),
             end=end,
             interval="1m",
+            prepost=self.prepost,
         )
         historical: pd.DataFrame = yfinance.download(
             self.symbol,
@@ -303,6 +307,7 @@ class Ticker:
             end=end,
             interval=self.interval,
             timeout=None,  # type: ignore
+            prepost=self.prepost,
         )
         if historical.empty:
             raise ValueError("No historical data returned from yfinance API.")

--- a/tinyticker/ticker.py
+++ b/tinyticker/ticker.py
@@ -370,6 +370,7 @@ class Sequence:
                     mav=ticker.mav,
                     volume=ticker.volume,
                     avg_buy_price=ticker.avg_buy_price,
+                    prepost=ticker.prepost,
                 )
                 for ticker in tt_config.tickers
             ],

--- a/tinyticker/web/app.py
+++ b/tinyticker/web/app.py
@@ -112,6 +112,7 @@ def create_app(config_file: Path = CONFIG_FILE, log_dir: Path = LOG_DIR) -> Flas
         tickers["avg_buy_price"] = request.args.getlist(
             "avg_buy_price", type=no_empty_float
         )
+        tickers["prepost"] = request.args.getlist("prepost", type=str_to_bool)
 
         sequence = SequenceConfig(
             skip_outdated=request.args.get("skip_outdated", False, type=bool),

--- a/tinyticker/web/templates/index.html
+++ b/tinyticker/web/templates/index.html
@@ -27,13 +27,6 @@
     <script src="js/uikit.min.js"></script>
     <script src="js/uikit-icons.min.js"></script>
     <script src="js/index.js"></script>
-    <script>
-      checkForUpdate("{{version}}").then((isUpdateAvailable) => {
-        document.getElementById("updateDiv").style.display = isUpdateAvailable
-          ? "block"
-          : "none";
-      });
-    </script>
   </head>
   <body class="uk-background-muted uk-padding-small">
     <div class="uk-flex uk-flex-center uk-flex-middle">
@@ -162,6 +155,7 @@
                         class="uk-select"
                         id="symbol_type"
                         name="symbol_type"
+                        onchange="hide_prepost(this)"
                       >
                         {%- for symbol_type_option in symbol_type_options -%}
                           <option
@@ -256,8 +250,7 @@
                         value="{{ ticker.avg_buy_price if ticker.avg_buy_price is not none }}"
                         uk-tooltip="Optional, used to display percentage change from buy price."
                       />
-                      <label class="uk-form-label" for="volume"
-                        >Show trade volume
+                      <label class="uk-form-label" for="volume">
                         <input
                           type="hidden"
                           name="volume"
@@ -269,6 +262,25 @@
                           {% if ticker.volume | default(False) %}checked{% endif %}
                           onclick="this.previousElementSibling.value=1-this.previousElementSibling.value"
                         />
+                        Show trade volume
+                      </label>
+                      <label
+                        class="uk-form-label"
+                        for="volume"
+                        uk-tooltip="Show pre/post market stock data."
+                      >
+                        <input
+                          type="hidden"
+                          name="prepost"
+                          value="{{ 1 if ticker.prepost | default(false) else 0 }}"
+                        />
+                        <input
+                          class="uk-checkbox"
+                          type="checkbox"
+                          {% if ticker.prepost| default(False) %}checked{% endif %}
+                          onclick="this.previousElementSibling.value=1-this.previousElementSibling.value"
+                        />
+                        Fetch pre/post market data
                       </label>
                     </div>
                   {%- endfor -%}
@@ -346,4 +358,16 @@
       </span>
     </div>
   </body>
+  <script>
+    checkForUpdate("{{version}}").then((isUpdateAvailable) => {
+      document.getElementById("updateDiv").style.display = isUpdateAvailable
+        ? "block"
+        : "none";
+    });
+
+    // run hide_prepost on all tickers
+    document.querySelectorAll("#symbol_type").forEach((element) => {
+      hide_prepost(element);
+    });
+  </script>
 </html>

--- a/tinyticker/web/templates/js/index.js
+++ b/tinyticker/web/templates/js/index.js
@@ -3,7 +3,7 @@ function add_ticker() {
   let last_ticker = tickers[tickers.length - 1];
   let new_ticker = last_ticker.cloneNode(true);
   new_ticker.className += " uk-animation-slide-right";
-  new_ticker.addEventListener("animationend", function() {
+  new_ticker.addEventListener("animationend", function () {
     new_ticker.classList.remove("uk-animation-slide-right");
   });
   last_ticker.insertAdjacentElement("afterend", new_ticker);
@@ -15,10 +15,20 @@ function remove_ticker(element) {
     return;
   }
   let ticker = element.parentNode.parentNode;
-  ticker.addEventListener("animationend", function() {
+  ticker.addEventListener("animationend", function () {
     ticker.parentNode.removeChild(ticker);
   });
   ticker.className += " uk-animation-slide-top uk-animation-reverse";
+}
+
+function hide_prepost(element) {
+  // if the symbol type is not a stock then hide the prepost checkbox
+  let prepost = element.parentElement.querySelector('[name="prepost"]');
+  if (element.value !== "stock") {
+    prepost.parentElement.style.display = "none";
+  } else {
+    prepost.parentElement.style.display = "block";
+  }
 }
 
 /**
@@ -45,4 +55,3 @@ async function checkForUpdate(currentVersion) {
   const pypiVersion = data.info.version;
   return isGreater(pypiVersion, currentVersion);
 }
-


### PR DESCRIPTION
adds an option to fetch the pre and post data for stock tickers.

Here is what it looks like in the ui, the option is hidden for crypto tickers as it isn't relevant:
![image](https://github.com/loiccoyle/tinyticker/assets/33181239/ef8d40da-0f08-485c-ab0d-6f3e37fd5e49)

closes #47 

Before I merge, @MojoOne1 let me know what you think.